### PR TITLE
Fix jsonrpc client bug: submit should not retry on StaleResponseError

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 group 'com.diem'
-version '1.0.4'
+version '1.0.5'
 
 apply plugin: 'java-library'
 apply plugin: 'java'

--- a/src/main/java/com/diem/jsonrpc/LedgerState.java
+++ b/src/main/java/com/diem/jsonrpc/LedgerState.java
@@ -18,6 +18,20 @@ public class LedgerState {
         this.chainId = chainId;
     }
 
+    public LedgerState(ChainId chainId, long version, long timestampUsecs) {
+        this.chainId = chainId;
+        this.version = version;
+        this.timestampUsecs = timestampUsecs;
+    }
+
+    public synchronized ChainId getChainId() {
+        return chainId;
+    }
+
+    public synchronized long getVersion() {
+        return version;
+    }
+
     /**
      * @return timestamp in micro-seconds
      */

--- a/src/test/java/com/diem/TestNetIntegrationTest.java
+++ b/src/test/java/com/diem/TestNetIntegrationTest.java
@@ -197,19 +197,21 @@ public class TestNetIntegrationTest {
     }
 
     @Test
-    public void testWaitForTransaction_timeout() {
+    public void testWaitForTransaction_timeout() throws DiemException {
         long expirationTimeSec = nowInSeconds(5);
+        JsonRpc.Account account = client.getAccount(Constants.ROOT_ACCOUNT_ADDRESS);
         assertThrows("transaction not found within timeout period", DiemTransactionWaitTimeoutException.class,
-                () -> client.waitForTransaction(Constants.ROOT_ACCOUNT_ADDRESS, 100,
+                () -> client.waitForTransaction(Constants.ROOT_ACCOUNT_ADDRESS, account.getSequenceNumber() + 1000,
                         "28f8151939d68b692d296028ca54bb7e9e92a2f9543effd2a424a79df67d0071",
                         expirationTimeSec, 0));
     }
 
     @Test
-    public void testWaitForTransaction_transactionExpired() {
+    public void testWaitForTransaction_transactionExpired() throws DiemException {
         long expirationTimeSec = nowInSeconds(0);
+        JsonRpc.Account account = client.getAccount(Constants.ROOT_ACCOUNT_ADDRESS);
         assertThrows("transaction not found within timeout period", DiemTransactionExpiredException.class,
-                () -> client.waitForTransaction(Constants.ROOT_ACCOUNT_ADDRESS, 1,
+                () -> client.waitForTransaction(Constants.ROOT_ACCOUNT_ADDRESS, account.getSequenceNumber() + 1000,
                         "28f8151939d68b692d296028ca54bb7e9e92a2f9543effd2a424a79df67d0071",
                         expirationTimeSec, 5));
     }


### PR DESCRIPTION
see https://github.com/diem/client-sdks/blob/master/specs/json_rpc_client.md#submit-transaction-api-should-ignore-stale-response-error for more details